### PR TITLE
Clipboard Paste Functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,17 +153,18 @@
     </div>
     <div id="drop_area">
         <div id="image-placeholder" style="z-index: 100;"
-            class="d-flex flex-column justify-content-center align-items-center position-absolute top-50 start-50 translate-middle">
-            <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="#FF007F" class="bi bi-cloud-arrow-up"
-                viewBox="0 0 16 16">
-                <path fill-rule="evenodd"
-                    d="M7.646 5.146a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 6.707V10.5a.5.5 0 0 1-1 0V6.707L6.354 7.854a.5.5 0 1 1-.708-.708l2-2z" />
-                <path
+        class="d-flex flex-column justify-content-center align-items-center position-absolute top-50 start-50 translate-middle">
+        <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="#FF007F" class="bi bi-cloud-arrow-up"
+            viewBox="0 0 16 16">
+            <path fill-rule="evenodd"
+                d="M7.646 5.146a.5.5 0 0 1 .708 0l2 2a.5.5 0 0 1-.708.708L8.5 6.707V10.5a.5.5 0 0 1-1 0V6.707L6.354 7.854a.5.5 0 1 1-.708-.708l2-2z" />
+            <path
                     d="M4.406 3.342A5.53 5.53 0 0 1 8 2c2.69 0 4.923 2 5.166 4.579C14.758 6.804 16 8.137 16 9.773 16 11.569 14.502 13 12.687 13H3.781C1.708 13 0 11.366 0 9.318c0-1.763 1.266-3.223 2.942-3.593.143-.863.698-1.723 1.464-2.383zm.653.757c-.757.653-1.153 1.44-1.153 2.056v.448l-.445.049C2.064 6.805 1 7.952 1 9.318 1 10.785 2.23 12 3.781 12h8.906C13.98 12 15 10.988 15 9.773c0-1.216-1.02-2.228-2.313-2.228h-.5v-.5C12.188 4.825 10.328 3 8 3a4.53 4.53 0 0 0-2.941 1.1z" />
-            </svg>
-            Drop image here
-            <input type="file" id="fileInput" style="display: none;" accept="image/*">
-
+                </svg>
+                <div class="text-center">
+                    <p class="mb-1">Drag and drop an image here or paste (Ctrl+V / ⌘V)</p>
+                </div>
+                <input type="file" id="fileInput" style="display: none;" accept="image/*">
             <button id="file-upload-button" class="tool-btn">or select an image</button>
         </div>
         <canvas id="canvas" width="800" height="600"></canvas>


### PR DESCRIPTION
# Add clipboard image paste support

Adds the ability to paste images directly from the clipboard into the canvas using Ctrl/Cmd+V. 

## Features
- Supports pasting PNG and JPEG images from clipboard
- Automatically scales large images to fit the canvas width
- Maintains consistent image positioning and layering behavior with drag-and-drop uploads
- Shows toast notifications for successful/failed paste attempts

## Testing
- Tested functionality in Zen browser (Firefox-based)
- Verified image scaling, positioning, and layer ordering
- Confirmed toast notifications work as expected
- Tested normal functionalities with keyboard shortcuts
  - Arrow
  - Rect
  - Emoji
  - Copy to Clipboard
  - Paste Image
  - Text