### PR TITLE
Fix keyboard shortcut numbers and help order

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,11 +198,11 @@
                     <ul class="list-unstyled">
                         <li><strong>(s)</strong>/<strong>(1)</strong> Select</li>
                         <li><strong>(a)</strong>/<strong>(2)</strong> Arrow</li>
-                        <li><strong>(r)</strong>/<strong>(3)</strong> Rectangle</li>
-                        <li><strong>(t)</strong>/<strong>(4)</strong> Text</li>
-                        <li><strong>(e)</strong>/<strong>(5)</strong> Emoji</li>
-                        <li><strong>(l)</strong>/<strong>(6)</strong> Line Segment</li>
-                        <li><strong>(o)</strong>/<strong>(7)</strong> Oval</li>
+                        <li><strong>(l)</strong>/<strong>(3)</strong> Line Segment</li>
+                        <li><strong>(r)</strong>/<strong>(4)</strong> Rectangle</li>
+                        <li><strong>(o)</strong>/<strong>(5)</strong> Oval</li>
+                        <li><strong>(t)</strong>/<strong>(6)</strong> Text</li>
+                        <li><strong>(e)</strong>/<strong>(7)</strong> Emoji</li>
                         <li><strong>(Ctrl-Z)</strong> Undo</li>
                         <li><strong>(Ctrl-Shift-Z)</strong> Redo</li>
                         <li><strong>(d)</strong> Download</li>

--- a/src/script.js
+++ b/src/script.js
@@ -444,11 +444,11 @@ document.addEventListener('keydown', function (e) {
     return;
   }
   switch (e.key) {
-    case '4':
+    case '6':
     case 't':
       setMode(Mode.TEXT);
       break;
-    case '3':
+    case '4':
     case 'r':
       setMode(Mode.RECT);
       break;
@@ -456,15 +456,15 @@ document.addEventListener('keydown', function (e) {
     case 'a':
       setMode(Mode.ARROW);
       break;
-    case '6':
+    case '3':
     case 'l':
       setMode(Mode.LINE);
       break;
-    case '7':
+    case '5':
     case 'o':
       setMode(Mode.OVAL);
       break;
-    case '5':
+    case '7':
     case 'e':
       openEmojiPicker()
       setMode(Mode.EMOJI)


### PR DESCRIPTION
With the new line and oval features, the numbers are now incorrect. This just sets the numbers to the right order.

Current state:

<img width="948" height="518" alt="a" src="https://github.com/user-attachments/assets/891e2f7a-48d6-4ff9-a0de-22f83513769e" />

New state:

1. Select
1. Arrow
1. Line Segment
1. Rectangle
1. Oval
1. Text
1. Emoji